### PR TITLE
cciframe component now embeds Customer's Canvas properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,9 +348,9 @@
       "integrity": "sha512-UrAZaS/up3YKS88z+OPgtqcTOAyKaKuuCBpnz42yhrmjQNXlQxPgHvYF+7m4bwoqkkGkM2B04lStYRtcvSy5oA=="
     },
     "@aurigma/design-atoms": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@aurigma/design-atoms/-/design-atoms-5.26.0.tgz",
-      "integrity": "sha512-Sjh8wGQyZHPE8Kuh7Z1wcCeiQ2Q9a9o5ax4glhcYwPnjwO0vJWJyA1rI/oqrxMhizSKqJrZQWQYXN/hi/a5WzA==",
+      "version": "5.25.0",
+      "resolved": "http://customerscanvas:4873/@aurigma%2fdesign-atoms/-/design-atoms-5.25.0.tgz",
+      "integrity": "sha512-UL4LfpPJ1W5uYQynAblbUiC2DCDmfyU8Utk/SYjBaLLKly3M4Oj5TkBpIYOkuQmo+E3j/vhtRrRw0SFmgJqs4w==",
       "requires": {
         "@types/underscore": "1.8.3",
         "clone": "2.1.1",
@@ -364,7 +364,7 @@
       "dependencies": {
         "clone": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "resolved": "http://customerscanvas:4873/clone/-/clone-2.1.1.tgz",
           "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
         }
       }
@@ -1529,7 +1529,7 @@
     },
     "@types/underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://customerscanvas:4873/@types%2funderscore/-/underscore-1.8.3.tgz",
       "integrity": "sha512-DP70788BXjp9+CKArXOUlNkZaXa+rHonDpbqH3/74ez16dLL5z2/bMT37etbln5J+H9M07NbRUyduDIoTM2tnw=="
     },
     "@webassemblyjs/ast": {
@@ -6437,7 +6437,7 @@
     },
     "json-cycle": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.3.0.tgz",
+      "resolved": "http://customerscanvas:4873/json-cycle/-/json-cycle-1.3.0.tgz",
       "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw=="
     },
     "json-parse-better-errors": {
@@ -6809,12 +6809,12 @@
     },
     "linq": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/linq/-/linq-3.2.1.tgz",
+      "resolved": "http://customerscanvas:4873/linq/-/linq-3.2.1.tgz",
       "integrity": "sha512-BEhjQpbvrKPWlg5m/+PXTHsQoXzzR0UWCvgI8Hm+WtUMtTwPvw9Tay5CWfqsWSVk81wqbHNDFpFXyqBmm4/dqA=="
     },
     "linq-iterator": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/linq-iterator/-/linq-iterator-3.0.5.tgz",
+      "resolved": "http://customerscanvas:4873/linq-iterator/-/linq-iterator-3.0.5.tgz",
       "integrity": "sha1-qwW+fHW2QYRZxRjgjPqvHN0TY1A=",
       "requires": {
         "linq": "^3.0.5"
@@ -11920,7 +11920,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://customerscanvas:4873/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -12211,7 +12211,7 @@
     },
     "vcard-parser": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vcard-parser/-/vcard-parser-1.0.0.tgz",
+      "resolved": "http://customerscanvas:4873/vcard-parser/-/vcard-parser-1.0.0.tgz",
       "integrity": "sha512-rSEjrjBK3of4VimMR5vBjLLcN5ZCSp9yuVzyx5i4Fwx74Yd0s+DnHtSit/wAAtj1a7/T/qQc0ykwXADoD0+fTQ=="
     },
     "vendors": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "~10.0.0-next.8",
     "@angular/platform-browser-dynamic": "~10.0.0-next.8",
     "@angular/router": "~10.0.0-next.8",
-    "@aurigma/design-atoms": "^5.26.0",
+    "@aurigma/design-atoms": "5.25.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.12.0",
     "zone.js": "~0.10.2"

--- a/src/app/cc/cciframe/cciframe.component.ts
+++ b/src/app/cc/cciframe/cciframe.component.ts
@@ -1,35 +1,28 @@
 import { AfterViewInit, Component, ElementRef, OnInit, ViewChild, Inject } from '@angular/core';
-import { Product, Surface } from '@aurigma/design-atoms/Model/Product';
-import { Viewer } from '@aurigma/design-atoms/Viewer/Viewer';
 import { DOCUMENT } from '@angular/common';
 
-  interface Window {
-    CustomersCanvas?: any;
-  }
-
+interface Window {
+  CustomersCanvas?: any;
+}
 
 @Component({
   selector: 'app-cciframe',
   templateUrl: './cciframe.component.html',
   styleUrls: ['./cciframe.component.scss']
 })
-export class CciframeComponent  implements OnInit, AfterViewInit {
+export class CciframeComponent implements OnInit, AfterViewInit {
+  customersCanvasBaseUrl = 'https://h.customerscanvas.com/Users/1f4b75ac-b0c2-46e5-88ed-d7f88c613250/SimplePolygraphy';
+  editor = null;
   productDefinition;
   scriptCreated;
 
   constructor( @Inject(DOCUMENT) private document: any,
   ) {
-    // (window as Window).CustomersCanvas = {
-    //   IframeApi: {
-    //     editorUrl: "http://localhost:4200/customerCanvasIframe"
-    //   }
-    // };
-    this.createScript();
   }
 
   ngOnInit() {
     this.productDefinition = {
-      //This safety line is applied to all surfaces of the product.
+      // This safety line is applied to all surfaces of the product.
       defaultSafetyLines: [{
         margin: 8.5,
         color: 'rgba(0,255,0,1)',
@@ -38,35 +31,44 @@ export class CciframeComponent  implements OnInit, AfterViewInit {
         widthPx: 1
       }],
       surfaces: [
-        //The first surface - a front side of the business card.
+        // The first surface - a front side of the business card.
         {
-          printAreas: [{ designFile: "BusinessCard2_side1" }]
+          printAreas: [{ designFile: 'samples/name-photo' }]
         },
-        //The second surface - a back side of the business card.
+        // The second surface - a back side of the business card.
         {
-          printAreas: [{ designFile: "BusinessCard2_side2" }]
+          printAreas: [{ designFile: 'samples/test-page' }]
         }]
     };
   }
 
-  ngAfterViewInit() {
-    //Getting the iframe element to display the editor in.
-    var iframe = document.getElementById("editorFrame");
-    //Loading the editor.
-    var config = { tokenId: "1f4b75ac-b0c2-46e5-88ed-d7f88c613250" };
-    var editor = null;
-    (window as Window).CustomersCanvas.IframeApi.loadEditor(iframe, this.productDefinition, config).then(function(e) {editor = e});
+  async ngAfterViewInit() {
+    await this.iframeApiReady();
+
+    // Getting the iframe element to display the editor in.
+    const iframe = document.getElementById('editorFrame');
+    // Loading the editor.
+    const config = {
+      initalMode: 'Advanced'
+     };
+    this.editor = await (window as Window).CustomersCanvas.IframeApi.loadEditor(iframe, this.productDefinition, config);
   }
 
-  createScript() {
-    (window as Window).customersCanvasReady = () => {
-      if (!this.scriptCreated) {
+  async iframeApiReady() {
+    return new Promise((resolve, reject) => {
+      if (this.document.getElementById('CcIframeApiScript')) {
+        resolve();
+      } else {
         const script = this.document.createElement('script');
         script.type = 'text/javascript';
-        script.src = `http://example.com/Resources/Generated/IframeApi.js`;
-        this.scriptCreated = true;
+        script.src = `${this.customersCanvasBaseUrl}/Resources/Generated/IframeApi.js`;
+        script.onload = resolve;
+        script.onerror = reject;
+        script.onabort = reject;
+        script.id = 'CcIframeApiScript';
         this.document.body.appendChild(script);
-        return;
       }
-    }
-  }}
+    });
+  }
+
+}

--- a/src/app/cc/cciframe/cciframe.component.ts
+++ b/src/app/cc/cciframe/cciframe.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnInit, ViewChild, Inject } from '@angular/core';
+import { AfterViewInit, Component, OnInit, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 
 interface Window {
@@ -10,11 +10,11 @@ interface Window {
   templateUrl: './cciframe.component.html',
   styleUrls: ['./cciframe.component.scss']
 })
+
 export class CciframeComponent implements OnInit, AfterViewInit {
   customersCanvasBaseUrl = 'https://h.customerscanvas.com/Users/1f4b75ac-b0c2-46e5-88ed-d7f88c613250/SimplePolygraphy';
   editor = null;
   productDefinition;
-  scriptCreated;
 
   constructor( @Inject(DOCUMENT) private document: any,
   ) {

--- a/src/app/cc/embedded/embedded.component.html
+++ b/src/app/cc/embedded/embedded.component.html
@@ -1,3 +1,4 @@
 <h1>Customer Canvas Embedded</h1>
-<div id="viewer-container" #viewerContainer>
+<div class="wrapper">
+    <div #viewerParent class="viewer-parent"></div>
 </div>

--- a/src/app/cc/embedded/embedded.component.scss
+++ b/src/app/cc/embedded/embedded.component.scss
@@ -1,0 +1,5 @@
+.viewer-parent {
+  height: 550px;
+  width: 100%;
+  background-color: #f8f9fa;
+}

--- a/src/app/cc/embedded/embedded.component.ts
+++ b/src/app/cc/embedded/embedded.component.ts
@@ -1,69 +1,126 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { Product, Surface, SafetyLine, PdfBox } from "@aurigma/design-atoms/Model/Product";
-import { SurfaceContainer} from "@aurigma/design-atoms/Model/Product";
-import { PrintArea } from "@aurigma/design-atoms/Model/Product";
-import { ImageItem, PlaceholderItem, PlainTextItem, BaseTextItem } from "@aurigma/design-atoms/Model/Product/Items";
-import { PointF } from "@aurigma/design-atoms/Math";
-import { MockupContainer } from "@aurigma/design-atoms/Model/Product";
-import { RectangleF } from "@aurigma/design-atoms/Math";
-import { RgbColor } from '@aurigma/design-atoms/Colors';
+import { Component, ElementRef, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { Product, Surface, SafetyLine, PdfBox } from '@aurigma/design-atoms/Model/Product';
+import { SurfaceContainer } from '@aurigma/design-atoms/Model/Product';
+import { PrintArea } from '@aurigma/design-atoms/Model/Product';
+import { ImageItem, PlaceholderItem, PlainTextItem, BaseTextItem, EllipseItem } from '@aurigma/design-atoms/Model/Product/Items';
+import { PointF } from '@aurigma/design-atoms/Math';
+import { MockupContainer } from '@aurigma/design-atoms/Model/Product';
+import { RectangleF } from '@aurigma/design-atoms/Math';
+import { RgbColor, CmykColor, ColorFactory } from '@aurigma/design-atoms/Colors';
+import { Viewer, IOptions } from '@aurigma/design-atoms/Viewer';
+import { Configuration } from '@aurigma/design-atoms/Configuration';
+import { SelectionHandler } from '@aurigma/design-atoms/SelectionHandler';
+
 
 @Component({
   selector: 'app-embedded',
   templateUrl: './embedded.component.html',
   styleUrls: ['./embedded.component.scss']
 })
-export class EmbeddedComponent implements OnInit {
-  placeholder: PlaceholderItem;
-  mainContainer: SurfaceContainer;
+export class EmbeddedComponent implements AfterViewInit, OnInit {
   product: Product;
-  mockupImg: ImageItem;
-  safetyLine: SafetyLine;
+  viewer: Viewer;
+
+  @ViewChild('viewerParent') viewerParent: ElementRef;
 
   constructor() { }
 
-  ngOnInit() {
-    this.product = new Product([new Surface(800, 800)]);
+  private initProduct() {
+
+    const width = 800;
+    const height = 800;
+
+    // Prepare a print area which will specify what portion of an image will be a part of a print file. Also, it contains
+    // the safety lines (bleed/trim zone)
+    const printarea = new PrintArea(new RectangleF(0, 0, width, height));
+    printarea.safetyLines.add(
+      new SafetyLine({
+        margin: 9,
+        pdfBox: PdfBox.Trim,
+        color: new RgbColor('lime'),
+        altColor: new RgbColor({a: 0, r: 0, b: 0, g: 0})}));
+
+    // Create a blank surface (page) with a single "layer" (container)
+    const page = new Surface(width, height, null, [printarea], 'Page 1', 'Page 1');
+    page.containers.add(new SurfaceContainer([], Configuration.MAIN_CONTAINER_NAME));
 
     // Create an image placeholder.
-    this.placeholder = new PlaceholderItem();
-    this.placeholder.content = new ImageItem(null, new PointF(100, 100), 200, 200);
-    this.placeholder.name = "photo";
+    const placeholder = new PlaceholderItem(new RectangleF(100, 100, 200, 200));
+    placeholder.name = 'photo';
 
-    // Create a main container with the placeholder.
-    this.mainContainer = new SurfaceContainer([this.placeholder]);
-    this.mainContainer.name = "main";
+    // Create a text item to the main container.
+    const nameItem = new PlainTextItem('Cristopher Bennett', new PointF(400, 100), 'Roboto-Bold', 25);
+    nameItem.locked = false;
+    nameItem.name = 'employee';
 
-    // Add a text item to the main container.
-    const nameItem = new PlainTextItem("Cristopher Bennett", new PointF(100, 400), "Roboto-Bold", 25);
-    nameItem.name = "employee";
-    this.mainContainer.items.add(nameItem);
+    const ellipse = new EllipseItem(new RectangleF(400, 200, 300, 200));
+    ellipse.fillColor = new RgbColor('rgb(255, 195, 0)');
 
-    // Add the main container to the surface.
-    const surface = this.product.surfaces.get(0);
-    surface.containers.setRange([this.mainContainer]);
+    const image = new ImageItem();
+    image.sourceRectangle = new RectangleF(100, 400, 640, 480);
+    image.source = new ImageItem.ImageSource(null, 'https://placeimg.com/640/480/any');
 
-    this.mockupImg = new ImageItem();
-    this.mockupImg.sourceRectangle = new RectangleF(0, 0, surface.width, surface.height);
-    this.mockupImg.source = new ImageItem.ImageSource(null, "https://example.com/mugmockup.png");
-    surface.mockup.overContainers.add(new MockupContainer([this.mockupImg]));
+    // Add these items to the main container
+    //
+    // Note, the collections in Design Atoms are implemented via the linq package. It brings to JavaScript the
+    // LINQ-like syntax of C# (AFAIK, the equivalent of LINQ in Java is Streams).
+    page.containers
+      .first(x => x.name === Configuration.MAIN_CONTAINER_NAME)
+      .items
+      .setRange([placeholder, image, nameItem, ellipse]);
 
-    const textItem = surface.containers.first().items.first(i => i.name === "employee") as BaseTextItem;
-    textItem.text = "John Wood";
+    // Create a product based on the page we have created
+    this.product = new Product([page]);
+  }
+
+  ngOnInit() {
+    this.initProduct();
   }
 
   ngAfterViewInit() {
+    (this.viewerParent.nativeElement as HTMLDivElement).innerHTML = '';
+
+    const options: IOptions = {
+      /*
+        You need the backend to render various graphics elements (like texts, images, etc), do color conversion if
+        are working with CMYK elements, etc.
+
+        All necessary endpoints are available in the standard Design Editor which we embed through cciframe. However,
+        in a real-life usage, most likely you will want to create a simpler backend app using the Aurigma.DesignAtoms
+        Nuget package (ASP.NET). We can help you with this part.
+      */
+      backendUrl: 'https://h.customerscanvas.com/Users/1f4b75ac-b0c2-46e5-88ed-d7f88c613250/SimplePolygraphy',
+      holderElement: this.viewerParent.nativeElement,
+      rulerEnabled: true,
+      canvasBackground: { color: 'white' }
+    };
+
+    this.viewer = new Viewer(options);
+    this.viewer.clearSelectionOnDocumentClick = true;
+    this.viewer.clearSelectionOnViewerClick = true;
+    this.viewer.rulerScale = 1 / 72; // points
+
+    this.viewer.canvas.rotationGripColor = 'rgb(255, 255, 255)';
+    this.viewer.canvas.rotationGripLineColor = 'rgb(48, 194, 255)';
+    this.viewer.canvas.rotationGripLineLength = 10;
+    this.viewer.canvas.rotationGripSize = 24;
+    this.viewer.canvas.selectionColor = 'rgb(48, 194, 255)';
+    this.viewer.canvas.selectionWidth = 1;
+
+    this.viewer.canvas.resizeGripLineColor = 'rgb(48, 194, 255)';
+    this.viewer.canvas.resizeGripColor = 'rgb(255, 255, 255)';
+    this.viewer.canvas.resizeGripSize = 8;
+
+    this.viewer.canvas.simpleMode = false;
+    this.viewer.canvas.canvasItemHoverEnabled = true;
+
+    // Specify the surface you want to display. If you have a multi-page product,
+    // you need to update this property when the user chooses another page.
+    this.viewer.surface = this.product.surfaces.get(0);
+
+    // Make safety lines visible
+    this.viewer.safetyLinesHandler.visible = true;
 
   }
 
-  setPrintArea() {
-    this.safetyLine = new SafetyLine();
-    this.safetyLine.margin = 10;
-    this.safetyLine.pdfBox = PdfBox.Bleed;
-    this.safetyLine.color = new RgbColor("lime");
-    const surface = this.product.surfaces.get(0);  // ?
-    const printArea = new PrintArea(new RectangleF(0, 0, surface.width, surface.height));
-    printArea.safetyLines.add(this.safetyLine);
-    surface.printAreas.add(printArea);
-  }
 }


### PR DESCRIPTION
Now the CC is embedded properly: 

- Replaced `createScript` by a function `iframeApiReady` which returns a promise that resolves when the script is loaded and ready.
- Before you use CustomersCanvas.IFrame namespace, now you need to wait for iframeApiReady promise
- A working CC base URL is used as a default value
- Existing designs are used in the `productDefinition`
- No need to use `tokenId` until your backend will register users in CC backend using auth api. Removed it, replaced by another minimalistic config example.
- Minor changes to please the linter (like whitespaces, quotes, etc).