### PR TITLE
Added an example how to work with design elements through IFrame API …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # dependencies
 /node_modules
+**/node_modules
 
 # profiling files
 chrome-profiler-events*.json

--- a/angular.json
+++ b/angular.json
@@ -123,6 +123,46 @@
           }
         }
       }
+    },
+    "design-editor-iframe": {
+      "projectType": "library",
+      "root": "projects/design-editor-iframe",
+      "sourceRoot": "projects/design-editor-iframe/src",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-ng-packagr:build",
+          "options": {
+            "tsConfig": "projects/design-editor-iframe/tsconfig.lib.json",
+            "project": "projects/design-editor-iframe/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "projects/design-editor-iframe/tsconfig.lib.prod.json"
+            }
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "projects/design-editor-iframe/src/test.ts",
+            "tsConfig": "projects/design-editor-iframe/tsconfig.spec.json",
+            "karmaConfig": "projects/design-editor-iframe/karma.conf.js"
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "projects/design-editor-iframe/tsconfig.lib.json",
+              "projects/design-editor-iframe/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
+          }
+        }
+      }
     }},
   "defaultProject": "demo2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,41 @@
         "worker-plugin": "4.0.3"
       }
     },
+    "@angular-devkit/build-ng-packagr": {
+      "version": "0.1000.0-rc.0",
+      "resolved": "http://customerscanvas:4873/@angular-devkit%2fbuild-ng-packagr/-/build-ng-packagr-0.1000.0-rc.0.tgz",
+      "integrity": "sha512-pDvlaqpRCnzjb2MTYeSRMI/r9N4OcOkg3LVQdaZboqeJRSBfBzvjxlYiSO6n+PmCIqt+KjYIIuBuJ/LsFBhrJw==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/architect": "0.1000.0-rc.0",
+        "rxjs": "6.5.5"
+      },
+      "dependencies": {
+        "@angular-devkit/architect": {
+          "version": "0.1000.0-rc.0",
+          "resolved": "http://customerscanvas:4873/@angular-devkit%2farchitect/-/architect-0.1000.0-rc.0.tgz",
+          "integrity": "sha512-NGh6Onl0RN4z0fEU7cUUK8AEDjTZdzzgYv2U+/t1AwK8vogsvfwEor7pOKxiCB/MMotpp+/THKTGFPrlvPcUXA==",
+          "dev": true,
+          "requires": {
+            "@angular-devkit/core": "10.0.0-rc.0",
+            "rxjs": "6.5.5"
+          }
+        },
+        "@angular-devkit/core": {
+          "version": "10.0.0-rc.0",
+          "resolved": "http://customerscanvas:4873/@angular-devkit%2fcore/-/core-10.0.0-rc.0.tgz",
+          "integrity": "sha512-3hHDdWEVhUPzJPHCwV7KyAwPiKBo0SR6nTRxiF6mgR8d87+X+DGhJwB8+g5a7cumRVm8b8CrziCxosQCOR7z+g==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.12.2",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.5.5",
+            "source-map": "0.7.3"
+          }
+        }
+      }
+    },
     "@angular-devkit/build-optimizer": {
       "version": "0.1000.0-next.6",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1000.0-next.6.tgz",
@@ -1438,6 +1473,62 @@
         "webpack-sources": "1.4.3"
       }
     },
+    "@rollup/plugin-commonjs": {
+      "version": "11.1.0",
+      "resolved": "http://customerscanvas:4873/@rollup%2fplugin-commonjs/-/plugin-commonjs-11.1.0.tgz",
+      "integrity": "sha512-Ycr12N3ZPN96Fw2STurD21jMqzKwL9QuFhms3SD7KKRK7oaXUsBU9Zt0jL/rOPHiPYisI21/rXGO3jr9BnLHUA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "commondir": "^1.0.1",
+        "estree-walker": "^1.0.1",
+        "glob": "^7.1.2",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0"
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.0.3",
+      "resolved": "http://customerscanvas:4873/@rollup%2fplugin-json/-/plugin-json-4.0.3.tgz",
+      "integrity": "sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "7.1.3",
+      "resolved": "http://customerscanvas:4873/@rollup%2fplugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
+      "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.14.2"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.1.0",
+          "resolved": "http://customerscanvas:4873/builtin-modules/-/builtin-modules-3.1.0.tgz",
+          "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+          "dev": true
+        }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.0.10",
+      "resolved": "http://customerscanvas:4873/@rollup%2fpluginutils/-/pluginutils-3.0.10.tgz",
+      "integrity": "sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
     "@schematics/angular": {
       "version": "10.0.0-next.6",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-10.0.0-next.6.tgz",
@@ -1465,10 +1556,31 @@
         "semver-intersect": "1.4.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "http://customerscanvas:4873/@sindresorhus%2fis/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "http://customerscanvas:4873/@szmarczak%2fhttp-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "http://customerscanvas:4873/@types%2festree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/events": {
@@ -1515,11 +1627,26 @@
       "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg==",
       "dev": true
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "http://customerscanvas:4873/@types%2fnormalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
+    },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "http://customerscanvas:4873/@types%2fresolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/selenium-webdriver": {
       "version": "3.0.17",
@@ -1529,7 +1656,7 @@
     },
     "@types/underscore": {
       "version": "1.8.3",
-      "resolved": "http://customerscanvas:4873/@types%2funderscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha512-DP70788BXjp9+CKArXOUlNkZaXa+rHonDpbqH3/74ez16dLL5z2/bMT37etbln5J+H9M07NbRUyduDIoTM2tnw=="
     },
     "@webassemblyjs/ast": {
@@ -1868,6 +1995,55 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "ansi-align": {
+      "version": "3.0.0",
+      "resolved": "http://customerscanvas:4873/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://customerscanvas:4873/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "http://customerscanvas:4873/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://customerscanvas:4873/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "http://customerscanvas:4873/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "http://customerscanvas:4873/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -2106,6 +2282,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "http://customerscanvas:4873/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -2430,6 +2612,80 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "boxen": {
+      "version": "4.2.0",
+      "resolved": "http://customerscanvas:4873/boxen/-/boxen-4.2.0.tgz",
+      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^4.1.0",
+        "term-size": "^2.1.0",
+        "type-fest": "^0.8.1",
+        "widest-line": "^3.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "http://customerscanvas:4873/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://customerscanvas:4873/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://customerscanvas:4873/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://customerscanvas:4873/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://customerscanvas:4873/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "http://customerscanvas:4873/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "http://customerscanvas:4873/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2679,6 +2935,50 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "http://customerscanvas:4873/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "http://customerscanvas:4873/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "4.1.0",
+          "resolved": "http://customerscanvas:4873/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "http://customerscanvas:4873/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "http://customerscanvas:4873/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+          "dev": true
+        }
+      }
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -2804,6 +3104,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "http://customerscanvas:4873/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2847,6 +3153,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "2.2.0",
+      "resolved": "http://customerscanvas:4873/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
       "dev": true
     },
     "cli-cursor": {
@@ -2947,6 +3259,15 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "http://customerscanvas:4873/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "coa": {
@@ -3174,6 +3495,37 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "resolved": "http://customerscanvas:4873/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "http://customerscanvas:4873/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://customerscanvas:4873/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "connect": {
@@ -3543,6 +3895,12 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "http://customerscanvas:4873/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
@@ -3815,6 +4173,12 @@
         }
       }
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "http://customerscanvas:4873/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "dev": true
+    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -3885,6 +4249,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "http://customerscanvas:4873/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -3898,6 +4271,12 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "http://customerscanvas:4873/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -3925,6 +4304,12 @@
           "dev": true
         }
       }
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "http://customerscanvas:4873/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4204,6 +4589,12 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "http://customerscanvas:4873/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -4493,6 +4884,12 @@
         "ext": "^1.1.2"
       }
     },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "http://customerscanvas:4873/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4534,6 +4931,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "http://customerscanvas:4873/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {
@@ -5029,6 +5432,12 @@
         }
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "http://customerscanvas:4873/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -5256,6 +5665,15 @@
         }
       }
     },
+    "global-dirs": {
+      "version": "2.0.1",
+      "resolved": "http://customerscanvas:4873/global-dirs/-/global-dirs-2.0.1.tgz",
+      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -5282,6 +5700,25 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
+      }
+    },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "http://customerscanvas:4873/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -5424,6 +5861,12 @@
           }
         }
       }
+    },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "http://customerscanvas:4873/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
     },
     "hash-base": {
       "version": "3.1.0",
@@ -5749,6 +6192,12 @@
         "resolve-from": "^3.0.0"
       }
     },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "http://customerscanvas:4873/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -5809,6 +6258,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "injection-js": {
+      "version": "2.3.0",
+      "resolved": "http://customerscanvas:4873/injection-js/-/injection-js-2.3.0.tgz",
+      "integrity": "sha512-rhS6E5jv603kbaO72ylOt0hGF1LT03oqQ4GU5KOO0qSaRbIWmdUCHjXq+VT79jL6/NmXtw9ccfK6dh/CzjoYjA==",
       "dev": true
     },
     "inquirer": {
@@ -5980,6 +6435,15 @@
       "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "http://customerscanvas:4873/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
     "is-color-stop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
@@ -6078,10 +6542,40 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-installed-globally": {
+      "version": "0.3.2",
+      "resolved": "http://customerscanvas:4873/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "3.0.2",
+          "resolved": "http://customerscanvas:4873/is-path-inside/-/is-path-inside-3.0.2.tgz",
+          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+          "dev": true
+        }
+      }
+    },
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "http://customerscanvas:4873/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-npm": {
+      "version": "4.0.0",
+      "resolved": "http://customerscanvas:4873/is-npm/-/is-npm-4.0.0.tgz",
+      "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
       "dev": true
     },
     "is-number": {
@@ -6133,6 +6627,15 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "is-reference": {
+      "version": "1.1.4",
+      "resolved": "http://customerscanvas:4873/is-reference/-/is-reference-1.1.4.tgz",
+      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39"
       }
     },
     "is-regex": {
@@ -6194,6 +6697,12 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "http://customerscanvas:4873/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -6435,9 +6944,15 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "http://customerscanvas:4873/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
     "json-cycle": {
       "version": "1.3.0",
-      "resolved": "http://customerscanvas:4873/json-cycle/-/json-cycle-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.3.0.tgz",
       "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw=="
     },
     "json-parse-better-errors": {
@@ -6708,6 +7223,15 @@
         "source-map-support": "^0.5.5"
       }
     },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "http://customerscanvas:4873/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -6719,6 +7243,15 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "http://customerscanvas:4873/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
+      }
     },
     "less": {
       "version": "3.11.1",
@@ -6807,14 +7340,20 @@
         "immediate": "~3.0.5"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "http://customerscanvas:4873/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "linq": {
       "version": "3.2.1",
-      "resolved": "http://customerscanvas:4873/linq/-/linq-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/linq/-/linq-3.2.1.tgz",
       "integrity": "sha512-BEhjQpbvrKPWlg5m/+PXTHsQoXzzR0UWCvgI8Hm+WtUMtTwPvw9Tay5CWfqsWSVk81wqbHNDFpFXyqBmm4/dqA=="
     },
     "linq-iterator": {
       "version": "3.0.5",
-      "resolved": "http://customerscanvas:4873/linq-iterator/-/linq-iterator-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/linq-iterator/-/linq-iterator-3.0.5.tgz",
       "integrity": "sha1-qwW+fHW2QYRZxRjgjPqvHN0TY1A=",
       "requires": {
         "linq": "^3.0.5"
@@ -6931,6 +7470,12 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "http://customerscanvas:4873/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -7283,6 +7828,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "http://customerscanvas:4873/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
@@ -7575,6 +8126,126 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ng-packagr": {
+      "version": "10.0.0-next.2",
+      "resolved": "http://customerscanvas:4873/ng-packagr/-/ng-packagr-10.0.0-next.2.tgz",
+      "integrity": "sha512-PW2gviekjvOLz1WkOk7JxRpddrwVUPXbPMUGYVeVXpvoyS4qvDZl2I3JUkTB57WuiNQqAewG7/prfKVTctJqSA==",
+      "dev": true,
+      "requires": {
+        "@rollup/plugin-commonjs": "^11.0.2",
+        "@rollup/plugin-json": "^4.0.0",
+        "@rollup/plugin-node-resolve": "^7.1.0",
+        "ajv": "^6.10.2",
+        "autoprefixer": "^9.6.5",
+        "browserslist": "^4.7.0",
+        "chalk": "^4.0.0",
+        "chokidar": "^3.2.1",
+        "commander": "^5.0.0",
+        "cssnano-preset-default": "^4.0.7",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.2",
+        "injection-js": "^2.2.1",
+        "less": "^3.10.3",
+        "node-sass-tilde-importer": "^1.0.0",
+        "postcss": "^7.0.29",
+        "postcss-url": "^8.0.0",
+        "read-pkg-up": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "rollup": "^2.8.0",
+        "rollup-plugin-sourcemaps": "^0.6.0",
+        "rxjs": "^6.5.0",
+        "sass": "^1.23.0",
+        "stylus": "^0.54.7",
+        "terser": "^4.3.8",
+        "update-notifier": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "http://customerscanvas:4873/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "http://customerscanvas:4873/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://customerscanvas:4873/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://customerscanvas:4873/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "http://customerscanvas:4873/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.0.0",
+          "resolved": "http://customerscanvas:4873/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://customerscanvas:4873/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "http://customerscanvas:4873/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "http://customerscanvas:4873/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "http://customerscanvas:4873/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -7657,6 +8328,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.55.tgz",
       "integrity": "sha512-H3R3YR/8TjT5WPin/wOoHOUPHgvj8leuU/Keta/rwelEQN9pA/S2Dx8/se4pZ2LBxSd0nAGzsNzhqwa77v7F1w==",
       "dev": true
+    },
+    "node-sass-tilde-importer": {
+      "version": "1.0.2",
+      "resolved": "http://customerscanvas:4873/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz",
+      "integrity": "sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==",
+      "dev": true,
+      "requires": {
+        "find-parent-dir": "^0.3.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -8130,6 +8810,12 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "http://customerscanvas:4873/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -8177,6 +8863,26 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "http://customerscanvas:4873/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://customerscanvas:4873/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "pacote": {
       "version": "9.5.12",
@@ -9255,6 +9961,27 @@
         "uniqs": "^2.0.0"
       }
     },
+    "postcss-url": {
+      "version": "8.0.0",
+      "resolved": "http://customerscanvas:4873/postcss-url/-/postcss-url-8.0.0.tgz",
+      "integrity": "sha512-E2cbOQ5aii2zNHh8F6fk1cxls7QVFZjLPSrqvmiza8OuXLzIpErij8BDS5Y3STPfJgpIMNCPEr8JlKQWEoozUw==",
+      "dev": true,
+      "requires": {
+        "mime": "^2.3.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.0",
+        "postcss": "^7.0.2",
+        "xxhashjs": "^0.2.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.5",
+          "resolved": "http://customerscanvas:4873/mime/-/mime-2.4.5.tgz",
+          "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+          "dev": true
+        }
+      }
+    },
     "postcss-value-parser": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
@@ -9702,6 +10429,15 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "pupa": {
+      "version": "2.0.1",
+      "resolved": "http://customerscanvas:4873/pupa/-/pupa-2.0.1.tgz",
+      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "dev": true,
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -9803,6 +10539,18 @@
         "schema-utils": "^2.6.5"
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "http://customerscanvas:4873/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -9842,6 +10590,93 @@
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
         "util-promisify": "^2.1.0"
+      }
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "http://customerscanvas:4873/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "http://customerscanvas:4873/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "http://customerscanvas:4873/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "5.0.0",
+      "resolved": "http://customerscanvas:4873/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+      "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://customerscanvas:4873/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://customerscanvas:4873/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "http://customerscanvas:4873/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://customerscanvas:4873/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "http://customerscanvas:4873/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -9955,6 +10790,24 @@
         "regjsparser": "^0.6.4",
         "unicode-match-property-ecmascript": "^1.0.4",
         "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "4.1.1",
+      "resolved": "http://customerscanvas:4873/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "http://customerscanvas:4873/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
       }
     },
     "regjsgen": {
@@ -10146,6 +10999,15 @@
         }
       }
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "http://customerscanvas:4873/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -10236,6 +11098,28 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
+      }
+    },
+    "rollup-plugin-sourcemaps": {
+      "version": "0.6.2",
+      "resolved": "http://customerscanvas:4873/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.2.tgz",
+      "integrity": "sha512-9AwTKg3yRykwzemfLt71ySe0LvrAci+bpsOL1LaTYFk5BX4HF6X7DQfpHa74ANfSja3hyjiQkXCR8goSOnW//Q==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.9",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "http://customerscanvas:4873/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
       }
     },
     "run-async": {
@@ -10409,6 +11293,23 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
       "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "dev": true
+    },
+    "semver-diff": {
+      "version": "3.1.1",
+      "resolved": "http://customerscanvas:4873/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://customerscanvas:4873/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "semver-dsl": {
       "version": "1.0.1",
@@ -11433,6 +12334,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "http://customerscanvas:4873/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "style-loader": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
@@ -11603,6 +12510,12 @@
         }
       }
     },
+    "term-size": {
+      "version": "2.2.0",
+      "resolved": "http://customerscanvas:4873/term-size/-/term-size-2.2.0.tgz",
+      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+      "dev": true
+    },
     "terser": {
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
@@ -11751,6 +12664,12 @@
           }
         }
       }
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "http://customerscanvas:4873/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
     },
     "to-regex": {
       "version": "3.0.2",
@@ -11906,6 +12825,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "http://customerscanvas:4873/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
@@ -11920,7 +12848,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "http://customerscanvas:4873/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -11991,6 +12919,15 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "http://customerscanvas:4873/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
       }
     },
     "universal-analytics": {
@@ -12079,6 +13016,79 @@
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
+    "update-notifier": {
+      "version": "4.1.0",
+      "resolved": "http://customerscanvas:4873/update-notifier/-/update-notifier-4.1.0.tgz",
+      "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+      "dev": true,
+      "requires": {
+        "boxen": "^4.2.0",
+        "chalk": "^3.0.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.3.1",
+        "is-npm": "^4.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
+        "pupa": "^2.0.1",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "http://customerscanvas:4873/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://customerscanvas:4873/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://customerscanvas:4873/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://customerscanvas:4873/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://customerscanvas:4873/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "http://customerscanvas:4873/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -12120,6 +13130,23 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "http://customerscanvas:4873/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      },
+      "dependencies": {
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "http://customerscanvas:4873/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        }
       }
     },
     "use": {
@@ -12211,7 +13238,7 @@
     },
     "vcard-parser": {
       "version": "1.0.0",
-      "resolved": "http://customerscanvas:4873/vcard-parser/-/vcard-parser-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/vcard-parser/-/vcard-parser-1.0.0.tgz",
       "integrity": "sha512-rSEjrjBK3of4VimMR5vBjLLcN5ZCSp9yuVzyx5i4Fwx74Yd0s+DnHtSit/wAAtj1a7/T/qQc0ykwXADoD0+fTQ=="
     },
     "vendors": {
@@ -12961,6 +13988,15 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "http://customerscanvas:4873/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.0.0"
+      }
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -13045,6 +14081,18 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "http://customerscanvas:4873/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "ws": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -13053,6 +14101,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "http://customerscanvas:4873/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",
@@ -13081,6 +14135,15 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
+    },
+    "xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "http://customerscanvas:4873/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "dev": true,
+      "requires": {
+        "cuint": "^0.2.2"
+      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1000.0-next.6",
+    "@angular-devkit/build-ng-packagr": "~0.1000.0-next.6",
     "@angular/cli": "~10.0.0-next.6",
     "@angular/compiler-cli": "~10.0.0-next.8",
     "@types/node": "^12.11.1",
@@ -39,6 +40,7 @@
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~3.1.1",
     "karma-jasmine-html-reporter": "^1.4.2",
+    "ng-packagr": "^10.0.0-next.0",
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",

--- a/projects/design-editor-iframe/README.md
+++ b/projects/design-editor-iframe/README.md
@@ -1,0 +1,24 @@
+# DesignEditorIframe
+
+This library was generated with [Angular CLI](https://github.com/angular/angular-cli) version 10.0.0-next.8.
+
+## Code scaffolding
+
+Run `ng generate component component-name --project design-editor-iframe` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project design-editor-iframe`.
+> Note: Don't forget to add `--project design-editor-iframe` or else it will be added to the default project in your `angular.json` file. 
+
+## Build
+
+Run `ng build design-editor-iframe` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+## Publishing
+
+After building your library with `ng build design-editor-iframe`, go to the dist folder `cd dist/design-editor-iframe` and run `npm publish`.
+
+## Running unit tests
+
+Run `ng test design-editor-iframe` to execute the unit tests via [Karma](https://karma-runner.github.io).
+
+## Further help
+
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/projects/design-editor-iframe/karma.conf.js
+++ b/projects/design-editor-iframe/karma.conf.js
@@ -1,0 +1,32 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: require('path').join(__dirname, '../../coverage/design-editor-iframe'),
+      reports: ['html', 'lcovonly', 'text-summary'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/projects/design-editor-iframe/ng-package.json
+++ b/projects/design-editor-iframe/ng-package.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/design-editor-iframe",
+  "lib": {
+    "entryFile": "src/public-api.ts",
+    "umdModuleIds": {
+      "ramda": "ramda",
+      "tsmonad": "tsmonad"
+    }
+  },
+  "whitelistedNonPeerDependencies": [
+    "tslib",
+    "ramda",
+    "tsmonad"
+  ]
+}

--- a/projects/design-editor-iframe/package-lock.json
+++ b/projects/design-editor-iframe/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "design-editor-iframe",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/ramda": {
+      "version": "0.27.6",
+      "resolved": "http://customerscanvas:4873/@types%2framda/-/ramda-0.27.6.tgz",
+      "integrity": "sha512-ephagb0ZIAJSoS5I/qMS4Mqo1b/Nd50pWM+o1QO/dz8NF//GsCGPTLDVRqgXlVncy74KShfHzE5rPZXTeek4PA==",
+      "dev": true,
+      "requires": {
+        "ts-toolbelt": "^6.3.3"
+      }
+    },
+    "ramda": {
+      "version": "0.27.0",
+      "resolved": "http://customerscanvas:4873/ramda/-/ramda-0.27.0.tgz",
+      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA=="
+    },
+    "ts-toolbelt": {
+      "version": "6.9.4",
+      "resolved": "http://customerscanvas:4873/ts-toolbelt/-/ts-toolbelt-6.9.4.tgz",
+      "integrity": "sha512-muRZZqfOTOVvLk5cdnp7YWm6xX+kD/WL2cS/L4zximBRcbQSuMoTbQQ2ZZBVMs1gB0EZw1qThP+HrIQB35OmEw==",
+      "dev": true
+    },
+    "tsmonad": {
+      "version": "0.8.0",
+      "resolved": "http://customerscanvas:4873/tsmonad/-/tsmonad-0.8.0.tgz",
+      "integrity": "sha1-zjzxMZLzI9uPeMgfVKX1vEohMPw="
+    }
+  }
+}

--- a/projects/design-editor-iframe/package.json
+++ b/projects/design-editor-iframe/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "design-editor-iframe",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^10.0.0-next.8",
+    "@angular/core": "^10.0.0-next.8"
+  },
+  "dependencies": {
+    "ramda": "^0.27.0",
+    "tsmonad": "^0.8.0",
+    "tslib": "^1.12.0"
+  },
+  "devDependencies": {
+    "@types/ramda": "^0.27.6"
+  }
+}

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.component.html
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.component.html
@@ -1,0 +1,1 @@
+<iframe #designEditorFrame></iframe>

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.component.less
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.component.less
@@ -1,0 +1,12 @@
+:host {
+    width: 100%;
+    height: 100%;
+    display: flex;
+  
+    iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  }
+  

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.component.spec.ts
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DesignEditorIframeComponent } from './design-editor-iframe.component';
+
+describe('DesignEditorIframeComponent', () => {
+  let component: DesignEditorIframeComponent;
+  let fixture: ComponentFixture<DesignEditorIframeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DesignEditorIframeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DesignEditorIframeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.component.ts
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.component.ts
@@ -1,0 +1,64 @@
+import { curry, pipe, lensProp, set, __ } from 'ramda';
+import { maybe } from 'tsmonad';
+import { DOCUMENT } from '@angular/common';
+
+import { Component, OnInit, ElementRef, ViewChild, Input, EventEmitter, Output, Renderer2, Inject } from '@angular/core';
+
+// TODO: We will add typings for IFrame API when a public npm package is available
+type ExternalLoadEditorFunction = (iframeElem: HTMLElement, productDefinition: any, editorConfig: any, deprecated: any) => Promise<any>;
+export type LoadEditorFunction = (productDefinition: any, editorConfig: any) => Promise<any>;
+
+@Component({
+  selector: 'lib-design-editor-iframe',
+  templateUrl: './design-editor-iframe.component.html',
+  styleUrls: ['./design-editor-iframe.component.less']
+})
+
+export class DesignEditorIframeComponent implements OnInit {
+
+  @Input() url: string;
+  @ViewChild('designEditorFrame') iframeElement: ElementRef;
+
+  @Output() ready = new EventEmitter<LoadEditorFunction>();
+  @Output() failed = new EventEmitter<string>();
+
+  constructor(private renderer: Renderer2, @Inject(DOCUMENT) private document) { }
+
+  private createElementFromObject(elementType: string, objProps: object) {
+    const result = this.renderer.createElement(elementType);
+    for (const [key, value] of Object.entries(objProps)) {
+      result[key] = value;
+    }
+    return result;
+  }
+
+  ngOnInit(): void {
+    /*
+      In case if you are not familiar with a functional approach (tsmonad and ramda),
+      this code creates a <script> element, initializes its properties, adds onload which
+      emits the ready event.
+     */
+    maybe(this.url)
+      .map(u => pipe(
+        set(lensProp('src'), `${u}/Resources/Generated/IframeApi.js`),
+        set(lensProp('id'), 'CcIframeApiScript'),
+        set(lensProp('onload'), () => {
+          maybe((window as any).CustomersCanvas)
+            .map(cc => cc.IframeApi)
+            .map(i => curry<ExternalLoadEditorFunction>(i.loadEditor)(this.iframeElement.nativeElement, __, __, null))
+            .do({
+              just: f => this.ready.emit(f),
+              nothing: () => this.failed.emit('For some reasons, Customer\'s Canvas IFrame API is not available!')
+            });
+        }),
+        set(lensProp('onabort'), () => this.failed.emit('IFrame API script loading was aborted.')),
+        set(lensProp('onerror'), (msg: string) => this.failed.emit(msg))
+      )({}))
+      .map(p => this.createElementFromObject('script', p))
+      .do({
+        just: elem => this.renderer.appendChild(this.document.head, elem),
+        nothing: () => { throw new Error('You should provide the base URL of your Design Editor back end.'); }
+      });
+  }
+
+}

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.module.ts
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { DesignEditorIframeComponent } from './design-editor-iframe.component';
+
+@NgModule({
+  declarations: [DesignEditorIframeComponent],
+  imports: [
+  ],
+  exports: [DesignEditorIframeComponent]
+})
+export class DesignEditorIframeModule { }

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.service.spec.ts
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DesignEditorIframeService } from './design-editor-iframe.service';
+
+describe('DesignEditorIframeService', () => {
+  let service: DesignEditorIframeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DesignEditorIframeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/design-editor-iframe/src/lib/design-editor-iframe.service.ts
+++ b/projects/design-editor-iframe/src/lib/design-editor-iframe.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DesignEditorIframeService {
+
+  constructor() { }
+}

--- a/projects/design-editor-iframe/src/public-api.ts
+++ b/projects/design-editor-iframe/src/public-api.ts
@@ -1,0 +1,7 @@
+/*
+ * Public API Surface of design-editor-iframe
+ */
+
+export * from './lib/design-editor-iframe.service';
+export * from './lib/design-editor-iframe.component';
+export * from './lib/design-editor-iframe.module';

--- a/projects/design-editor-iframe/src/test.ts
+++ b/projects/design-editor-iframe/src/test.ts
@@ -1,0 +1,26 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'zone.js/dist/zone';
+import 'zone.js/dist/zone-testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/projects/design-editor-iframe/tsconfig.lib.json
+++ b/projects/design-editor-iframe/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "target": "es2015",
+    "declaration": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/projects/design-editor-iframe/tsconfig.lib.prod.json
+++ b/projects/design-editor-iframe/tsconfig.lib.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "enableIvy": false
+  }
+}

--- a/projects/design-editor-iframe/tsconfig.spec.json
+++ b/projects/design-editor-iframe/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/projects/design-editor-iframe/tslint.json
+++ b/projects/design-editor-iframe/tslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tslint.json",
+  "rules": {
+    "directive-selector": [
+      true,
+      "attribute",
+      "lib",
+      "camelCase"
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "lib",
+      "kebab-case"
+    ]
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,8 @@ import { AppComponent } from './app.component';
 import { CciframeComponent } from './cc/cciframe/cciframe.component';
 import { EmbeddedComponent } from './cc/embedded/embedded.component';
 
+import { DesignEditorIframeModule } from 'projects/design-editor-iframe/src/public-api';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -14,7 +16,8 @@ import { EmbeddedComponent } from './cc/embedded/embedded.component';
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    DesignEditorIframeModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/cc/cciframe/cciframe.component.html
+++ b/src/app/cc/cciframe/cciframe.component.html
@@ -1,2 +1,12 @@
 <h1>Customer Canvas Iframe</h1>
-<iframe id="editorFrame" width="100%" height="800px"></iframe>
+<button [disabled]="!editor ? true : null" (click)="setName()">Set Name</button>
+<button [disabled]="!editor ? true : null" (click)="addElement()">Add Element</button>
+<button [disabled]="!editor ? true : null" (click)="deleteSelection()">Delete Selection</button>
+<div class="cc-container">
+    <lib-design-editor-iframe 
+        [url]="customersCanvasBaseUrl"
+        (ready)="onIFrameReady($event)"
+        (failed)="onError($event)"
+        >
+    </lib-design-editor-iframe>
+</div>

--- a/src/app/cc/cciframe/cciframe.component.scss
+++ b/src/app/cc/cciframe/cciframe.component.scss
@@ -1,0 +1,3 @@
+.cc-container {
+    height: 80vh;
+}

--- a/src/app/cc/cciframe/cciframe.component.ts
+++ b/src/app/cc/cciframe/cciframe.component.ts
@@ -1,5 +1,6 @@
-import { AfterViewInit, Component, OnInit, Inject } from '@angular/core';
+import { AfterViewInit, Component, OnInit, Inject, ViewChild } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
+import { DesignEditorIframeComponent, LoadEditorFunction } from 'projects/design-editor-iframe/src/public-api';
 
 interface Window {
   CustomersCanvas?: any;
@@ -16,7 +17,9 @@ export class CciframeComponent implements OnInit, AfterViewInit {
   editor = null;
   productDefinition;
 
-  constructor( @Inject(DOCUMENT) private document: any,
+  @ViewChild(DesignEditorIframeComponent) private designEditorIFrame: DesignEditorIframeComponent;
+
+  constructor(@Inject(DOCUMENT) private document: any,
   ) {
   }
 
@@ -42,33 +45,88 @@ export class CciframeComponent implements OnInit, AfterViewInit {
     };
   }
 
-  async ngAfterViewInit() {
-    await this.iframeApiReady();
+  ngAfterViewInit() {
+  }
 
-    // Getting the iframe element to display the editor in.
-    const iframe = document.getElementById('editorFrame');
-    // Loading the editor.
+  onError(msg: string) {
+    throw new Error(`Customer's Canvas IFrame API failed with this message:\n${msg}`);
+  }
+
+  async onIFrameReady(loadEditor: LoadEditorFunction) {
     const config = {
-      initalMode: 'Advanced'
-     };
-    this.editor = await (window as Window).CustomersCanvas.IframeApi.loadEditor(iframe, this.productDefinition, config);
+      initialMode: 'Advanced'
+    };
+    this.editor = await loadEditor(this.productDefinition, config);
   }
 
-  async iframeApiReady() {
-    return new Promise((resolve, reject) => {
-      if (this.document.getElementById('CcIframeApiScript')) {
-        resolve();
-      } else {
-        const script = this.document.createElement('script');
-        script.type = 'text/javascript';
-        script.src = `${this.customersCanvasBaseUrl}/Resources/Generated/IframeApi.js`;
-        script.onload = resolve;
-        script.onerror = reject;
-        script.onabort = reject;
-        script.id = 'CcIframeApiScript';
-        this.document.body.appendChild(script);
-      }
-    });
+  // See for details:
+  // https://customerscanvas.com/docs/cc/introduction-to-iframe-api-v5.htm
+
+  async setName() {
+    if (!this.editor) { return; }
+
+    const product = await this.editor.getProduct();
+    const model = await product.getProductModel();
+
+    model
+      .getAllItems()
+      .forEach(async (x) => {
+        switch (true) {
+          case x.name.toLowerCase() === 'first name':
+            x.text = 'Richard';
+            await product.setItem(x);
+            break;
+          case x.name.toLowerCase() === 'last name':
+            x.text = 'Lemieux';
+            await product.setItem(x);
+            break;
+        }
+      });
+
+    // This is an easy way to set multiple changes to the editor, however, it would cause flickering of the editor.
+    // To avoid it, you can use `await product.setItem()` as in the switch/case above.
+    //
+    // await product.setProductModel(model);
   }
 
+  async deleteSelection() {
+    if (!this.editor) { return; }
+
+    const selection = (await this.editor.getSelectedItems())
+      .map(x => x.name);
+
+    const product = await this.editor.getProduct();
+    const model = await product.getProductModel();
+
+    const currentPageMainContainer = model
+      .surfaces
+      .get(product.currentSurfaceIndex)
+      .containers
+      .first(x => x.name === 'Main');
+
+    currentPageMainContainer.items.setRange(currentPageMainContainer
+      .items
+      .where(x => selection.indexOf(x.name) === -1)
+      .toArray());
+
+    await product.setProductModel(model);
+  }
+
+  async addElement() {
+    if (!this.editor) { return; }
+
+    // Until we add IFrame API as an npm package, you have to use
+    // a namespace from IFrameApi.js instead of imported Design Atoms.
+    const Model = (window as any).CustomersCanvas.DesignAtoms.ObjectModel;
+
+    // See for details:
+    // https://customerscanvas.com/docs/cc/introduction-to-iframe-api-v5.htm
+    const product = await this.editor.getProduct();
+
+    const rect = new Model.RectangleItem(new Model.RectangleF(50, 50, 100, 150));
+    rect.name = `Item ${Math.random().toString(36).substr(2, 5)}`;
+    rect.fillColor = new Model.ColorFactory.createColor('#DAF7A6');
+
+    product.currentSurface.insertItem(rect);
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,12 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "paths": {
+      "design-editor-iframe": [
+        "dist/design-editor-iframe/design-editor-iframe",
+        "dist/design-editor-iframe"
+      ]
+    }
   }
 }


### PR DESCRIPTION
…+ the IFrame wrapper is a separate lib now

I have decided that it would be better to decouple the component which wraps the `<iframe>` and ensures that the iframeapi.js is loaded and the code which works with the design. Now the `<lib-design-editor-iframe>` is located in **projects/design-editor-iframe/src/lib**. 

Note, before you can use it, it is necessary to build the library using the `ng build design-editor-iframe` command. Later, we will add this (or equivalent) component to our npm and you will just add it as an external dependency. 

This component is used like this (see cciframe.component.html):

```
    <lib-design-editor-iframe 
        [url]="customersCanvasBaseUrl"
        (ready)="onIFrameReady($event)"
        (failed)="onError($event)"
        >
    </lib-design-editor-iframe>
``` 

As you can see, this component has the ready event. The argument of this event is the loadEditor function, so the event handler looks like this (see cciframe.component.ts):

```
  async onIFrameReady(loadEditor: LoadEditorFunction) {
    const config = {
      initialMode: 'Advanced'
    };
    this.editor = await loadEditor(this.productDefinition, config);
  }
```

To demonstrate how to manipulate elements, I have created three buttons:

- Set name - illustrates how to modify the existing items
- Add element - illustrates how to add a new item to the model
- Delete selection - illustrates how to receive the list of selected elements and update the model by filtering out the selected elements (i.e. delete them).